### PR TITLE
Ddf-3567 Windows Fix 1.0 (Unfinished)

### DIFF
--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstaller.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstaller.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
@@ -52,8 +51,6 @@ public class ApplicationFileInstaller {
 
     private static final String REPO_LOCATION = "system" + File.separator;
 
-    private static final String URI_PROTOCOL = "file:";
-
     /**
      * Installs the given application file to the system repository.
      *
@@ -62,10 +59,10 @@ public class ApplicationFileInstaller {
      * @return A string URI that points to the main feature file for the
      *         application that was just installed.
      * @throws ApplicationServiceException
-     *             If any errors occur while trying to install the application
+     *             If any errors occur while trying to install the application.
      */
     public static URI install(File application) throws ApplicationServiceException {
-        // extract files to local repo
+        // Extract files to local repo
         ZipFile appZip = null;
         try {
             appZip = new ZipFile(application);
@@ -73,15 +70,11 @@ public class ApplicationFileInstaller {
                 LOGGER.debug("Installing {} to the system repository.",
                         application.getAbsolutePath());
                 String featureLocation = installToRepo(appZip);
-                String uri = //URI_PROTOCOL //+ "\\\\\\"
-                         new File("").getAbsolutePath()
-                        + File.separator
-                        + REPO_LOCATION
-                        + featureLocation;
+                String uri = new File("").getAbsolutePath()
+                        + File.separator + REPO_LOCATION + featureLocation;
 
-                // lets standardize the file separators in this uri.
+                // Lets standardize the file separators in this uri.
                 // It fails on windows if we do not use.
-                //uri = uri.replace("\\", "/");
                 return Paths.get(uri).toUri();
             }
 
@@ -89,11 +82,7 @@ public class ApplicationFileInstaller {
             LOGGER.warn("Got an error when trying to read the application as a zip file.", ze);
         } catch (IOException ioe) {
             LOGGER.warn("Got an error when trying to read the incoming application.", ioe);
-        } /*catch (URISyntaxException e) {
-            LOGGER.warn(
-                    "Installed application but could not obtain correct location to feature file.",
-                    e);
-        }*/ finally {
+        } finally {
             IOUtils.closeQuietly(appZip);
         }
 
@@ -103,11 +92,11 @@ public class ApplicationFileInstaller {
     /**
      * Detects and Builds an AppDetail based on the zip file provided.
      *
-     * To start the process, we find the features.xml file. Once we find it within the zipfile, we
+     * To start the process, we find the features.xml file. Once we find it within the zip file, we
      * specifically get a stream to that file. Next we parse through the features.xml and extract
      * the version/appname.
      *
-     * @param application
+     * @param applicationFile
      *            the file to detect appname and version from.
      * @return {@link ZipFileApplicationDetails} containing appname and version.
      * @throws ApplicationServiceException
@@ -122,20 +111,11 @@ public class ApplicationFileInstaller {
                     applicationFile.getAbsolutePath());
 
             ZipEntry featureFileEntry = getFeatureFile(appZip);
-            ZipFileApplicationDetails details = getAppDetailsFromFeature(appZip, featureFileEntry);
-            return details;
-        } catch (ZipException e) {
+            return getAppDetailsFromFeature(appZip, featureFileEntry);
+
+        } catch (IOException | SAXException | ParserConfigurationException e) {
             throw new ApplicationServiceException(
-                    "Could not get application details of the provided zipfile.", e);
-        } catch (IOException e) {
-            throw new ApplicationServiceException(
-                    "Could not get application details of the provided zipfile.", e);
-        } catch (ParserConfigurationException e) {
-            throw new ApplicationServiceException(
-                    "Could not get application details of the provided zipfile.", e);
-        } catch (SAXException e) {
-            throw new ApplicationServiceException(
-                    "Could not get application details of the provided zipfile.", e);
+                    "Could not get application details of the provided zip file.", e);
         } finally {
             IOUtils.closeQuietly(appZip);
         }
@@ -169,7 +149,7 @@ public class ApplicationFileInstaller {
      * REPO_LOCATION.
      *
      * @param appZip
-     *            the zipfile to extract.
+     *            the ZipFile to extract.
      * @return the detected feature file location.
      */
     private static String installToRepo(ZipFile appZip) {
@@ -196,10 +176,10 @@ public class ApplicationFileInstaller {
     }
 
     /**
-     * Loops through all zipFile entries to find the features.xml file.
+     * Loops through all of zipFile's entries to find the features.xml file.
      *
-     * @param zipFile
-     * @return
+     * @param zipFile The ZipFile to search for the feature file.
+     * @return The ZipEntry representing the features.xml file.
      */
     private static ZipEntry getFeatureFile(ZipFile zipFile) {
         Enumeration<?> entries = zipFile.entries();
@@ -217,8 +197,7 @@ public class ApplicationFileInstaller {
     /**
      * Detects if the given zip file entry matches the features.xml naming scheme.
      *
-     * @param entry
-     *            the zip entry to check
+     * @param entry The zip entry to check.
      * @return <code>true</code> if the zip entry matches the features.xml file naming scheme.
      */
     private static boolean isFeatureFile(ZipEntry entry) {
@@ -234,9 +213,9 @@ public class ApplicationFileInstaller {
      *            zip file get the {@link InputStream} from.
      * @param featureZipEntry
      *            the specific file pointing to the features.xml file.
-     * @return the {@link ZipFileApplicationDetails} of the given features.xml file.
+     * @return The {@link ZipFileApplicationDetails} of the given features.xml file.
      * @throws ApplicationServiceException
-     *             any error that occurs within this method, will be wrapped in this.
+     *             Any error that occurs within this method will be wrapped in this.
      * @throws ParserConfigurationException
      * @throws IOException
      * @throws SAXException

--- a/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstaller.java
+++ b/platform/admin/core/admin-core-appservice/src/main/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstaller.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -72,24 +73,27 @@ public class ApplicationFileInstaller {
                 LOGGER.debug("Installing {} to the system repository.",
                         application.getAbsolutePath());
                 String featureLocation = installToRepo(appZip);
-                String uri = URI_PROTOCOL + new File("").getAbsolutePath() + File.separator
-                        + REPO_LOCATION + featureLocation;
+                String uri = //URI_PROTOCOL //+ "\\\\\\"
+                         new File("").getAbsolutePath()
+                        + File.separator
+                        + REPO_LOCATION
+                        + featureLocation;
 
                 // lets standardize the file separators in this uri.
                 // It fails on windows if we do not use.
-                uri = uri.replace("\\", "/");
-                return new URI(uri);
+                //uri = uri.replace("\\", "/");
+                return Paths.get(uri).toUri();
             }
 
         } catch (ZipException ze) {
             LOGGER.warn("Got an error when trying to read the application as a zip file.", ze);
         } catch (IOException ioe) {
             LOGGER.warn("Got an error when trying to read the incoming application.", ioe);
-        } catch (URISyntaxException e) {
+        } /*catch (URISyntaxException e) {
             LOGGER.warn(
                     "Installed application but could not obtain correct location to feature file.",
                     e);
-        } finally {
+        }*/ finally {
             IOUtils.closeQuietly(appZip);
         }
 

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstallerTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstallerTest.java
@@ -23,9 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.net.URI;
-import java.net.URL;
 
-import org.codice.ddf.admin.application.service.Application;
 import org.codice.ddf.admin.application.service.ApplicationServiceException;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,11 +76,7 @@ public class ApplicationFileInstallerTest {
     @Test
     public void testInstall() throws Exception {
 
-        ApplicationFileInstaller testInstaller = new ApplicationFileInstaller();
         File testFile = new File(File.class.getResource(TEST_FILE_NAME).getPath());
-
-        //boolean match =
-        //        ApplicationFileInstaller.install(testFile).getPath().matches("(/.+)+");
 
         URI mUri = ApplicationFileInstaller.install(testFile);
         String mPath = mUri.getPath();

--- a/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstallerTest.java
+++ b/platform/admin/core/admin-core-appservice/src/test/java/org/codice/ddf/admin/application/service/impl/ApplicationFileInstallerTest.java
@@ -22,7 +22,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.net.URI;
+import java.net.URL;
 
+import org.codice.ddf.admin.application.service.Application;
 import org.codice.ddf.admin.application.service.ApplicationServiceException;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,8 +81,14 @@ public class ApplicationFileInstallerTest {
         ApplicationFileInstaller testInstaller = new ApplicationFileInstaller();
         File testFile = new File(File.class.getResource(TEST_FILE_NAME).getPath());
 
-        assertTrue("Returned URI should have a unix-style path",
-                testInstaller.install(testFile).getPath().matches("(/.+)+"));
+        //boolean match =
+        //        ApplicationFileInstaller.install(testFile).getPath().matches("(/.+)+");
+
+        URI mUri = ApplicationFileInstaller.install(testFile);
+        String mPath = mUri.getPath();
+        boolean mMatch = mPath.matches("(/.+)+");
+
+        assertTrue("Returned URI should have a unix-style path", mMatch);
 
         verify(mockAppender).doAppend(argThat(new ArgumentMatcher() {
             @Override

--- a/platform/security/core/security-core-impl/src/main/java/ddf/security/common/util/Security.java
+++ b/platform/security/core/security-core-impl/src/main/java/ddf/security/common/util/Security.java
@@ -231,7 +231,23 @@ public class Security {
                     System.getProperty("javax.net.ssl.keyStoreType"), e);
             return null;
         }
-        Path keyStoreFile = Paths.get(System.getProperty("javax.net.ssl.keyStore"));
+
+        // TODO: FIX ABSOLUTE PATH ASSIGNMENTS TO SYSTEM PROPERTIES
+        //      This is the "band-aid" for the problem so we can get a build running
+        //      This is not a permanent fix!!!
+        //  ------------------------------------------------------------------------
+        String propValue = System.getProperty("javax.net.ssl.keyStore");
+
+        // Instead of removing the ':', we remove the first slash IFF on windows
+        //  by computing a regular expression that detects the colon
+        propValue = propValue.replaceFirst("^/(.:/)", "$1");
+
+        //propValue = propValue.replace(":", "");
+        Path keyStoreFile = Paths.get(propValue);
+
+        //  ------------------------------------------------------------------------
+        //ORIGINAL CODE:
+        //Path keyStoreFile = Paths.get(System.getProperty("javax.net.ssl.keyStore"));
 
         Path ddfHomePath = Paths.get(System.getProperty("ddf.home"));
         if (!keyStoreFile.isAbsolute()) {

--- a/platform/security/core/security-core-impl/src/test/java/ddf/security/common/util/SecurityTest.java
+++ b/platform/security/core/security-core-impl/src/test/java/ddf/security/common/util/SecurityTest.java
@@ -133,6 +133,9 @@ public class SecurityTest {
     }
 
     @Test
+    /* TODO: Test 1 causing path exceptions
+        Bad format in the value of system property: "javax.net.ssl.keyStore"
+    */
     public void testGetSystemSubject() throws Exception {
         System.setProperty("org.codice.ddf.system.hostname", "server");
         configurMocksForBundleContext();
@@ -141,6 +144,9 @@ public class SecurityTest {
     }
 
     @Test
+    /* TODO: Test 2 causing path exceptions
+        Bad format in the value of system property: "javax.net.ssl.keyStore"
+    */
     public void testGetSystemSubjectBadAlias() throws Exception {
         System.setProperty("org.codice.ddf.system.hostname", "bad-alias");
         configurMocksForBundleContext();

--- a/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/XMLUtilsTest.java
+++ b/platform/util/platform-util/src/test/java/org/codice/ddf/platform/util/XMLUtilsTest.java
@@ -43,9 +43,14 @@ public class XMLUtilsTest {
 
     private static final String XML = "<node>Valid-XML</node>";
 
-    private static final String PRETTY_XML_SOURCE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><node>Valid-XML</node>\n";
+    private static final String PRETTY_XML_SOURCE =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><node>Valid-XML</node>"
+            + System.lineSeparator();
 
-    private static final String PRETTY_XML_NODE = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<node>Valid-XML</node>\n";
+    private static final String PRETTY_XML_NODE =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>"
+            + System.lineSeparator() + "<node>Valid-XML</node>"
+            + System.lineSeparator();
 
     @Test
     public void testFormatSource() throws ParserConfigurationException, IOException, SAXException {


### PR DESCRIPTION
Booted up DDF on Windows 8.1 and systematically went through each MAVEN error that was reported. Progress will resume with the following failed, unaddressed tests: 
- testValidateToken
- testValidateAnyRealmToken

They are both in ddf.security.validator.pki and the surefire reports can be found in platform/security/sts/security-sts-pkivalidator/target/surefire-reports. 
